### PR TITLE
Unescape actual string in details

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -144,7 +144,7 @@ test_content = <<~'RUBY'
     it "match (regex)" do
       expect("user@example.com").to match(/admin@/)
     end
-
+    
     it "contain_exactly" do
       expect([1, 2, 3]).to contain_exactly(1, 2, 4)
     end

--- a/demo.rb
+++ b/demo.rb
@@ -144,7 +144,7 @@ test_content = <<~'RUBY'
     it "match (regex)" do
       expect("user@example.com").to match(/admin@/)
     end
-    
+
     it "contain_exactly" do
       expect([1, 2, 3]).to contain_exactly(1, 2, 4)
     end
@@ -162,6 +162,10 @@ test_content = <<~'RUBY'
       expect("Hello").to match("Goodbye")
     end
     
+    it "unescaping quotes in actual" do
+      expect("\"Hello, ---world\"").to match("Hello, world")
+    end
+
     # Change Matchers
     it "change" do
       x = 5
@@ -380,7 +384,7 @@ Tempfile.create(["demo_test", ".rb"]) do |test_file|
       "Truthiness Matchers" => ["be_truthy", "be_falsey / be_falsy", "be_nil"],
       "Predicate Matchers" => ["be_empty", "have_key"],
       "Collection Matchers" => ["include", "include with multiple items", "include with hash", "start_with", "end_with", "match (regex)", "contain_exactly", "match_array", "all"],
-      "String Matchers" => ["match with string"],
+      "String Matchers" => ["match with string", "unescaping quotes in actual"],
       "Change Matchers" => ["change", "change by", "change by_at_least", "change by_at_most"],
       "Output Matchers" => ["output to stdout", "output to stderr"],
       "Exception Matchers" => ["raise_error", "raise_error with message", "raise_error when none raised", "unexpected exception (outside expect block)"],

--- a/lib/rspec/enriched_json/expectation_helper_wrapper.rb
+++ b/lib/rspec/enriched_json/expectation_helper_wrapper.rb
@@ -32,7 +32,7 @@ module RSpec
           when nil, Numeric, TrueClass, FalseClass
             value
           when String
-            unescape_string(
+            unescape_string_double_quotes(
               truncate_string(value)
             )
           when Symbol
@@ -81,7 +81,7 @@ module RSpec
           "#{str[0...MAX_STRING_LENGTH]}... (truncated)"
         end
 
-        def unescape_string(str)
+        def unescape_string_double_quotes(str)
           if str.start_with?('"') && str.end_with?('"')
             return str.undump
           else

--- a/lib/rspec/enriched_json/expectation_helper_wrapper.rb
+++ b/lib/rspec/enriched_json/expectation_helper_wrapper.rb
@@ -32,7 +32,9 @@ module RSpec
           when nil, Numeric, TrueClass, FalseClass
             value
           when String
-            truncate_string(value)
+            unescape_string(
+              truncate_string(value)
+            )
           when Symbol
             value.to_s
           when Array
@@ -77,6 +79,14 @@ module RSpec
         def truncate_string(str)
           return str if str.length <= MAX_STRING_LENGTH
           "#{str[0...MAX_STRING_LENGTH]}... (truncated)"
+        end
+
+        def unescape_string(str)
+          if str.start_with?('"') && str.end_with?('"')
+            return str.undump
+          else
+            str
+          end
         end
 
         def safe_inspect(obj)

--- a/spec/diff_info_spec.rb
+++ b/spec/diff_info_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe "diffable" do
       test_content = <<~RUBY
         RSpec.describe "String diff" do
           it "compares strings" do
-            expect('"Hello, ---world"').to match("Hello, world")  
+            expect("\\"Hello, ---world\\"").to match("Hello, world")
           end
         end
       RUBY
 
       output = run_formatter_with_content(test_content)
-      # p output
       details = output["examples"].first["details"]
+
       expect(details["expected"]).to eq("Hello, world")
       expect(details["actual"]).to eq("Hello, ---world")
     end

--- a/spec/diff_info_spec.rb
+++ b/spec/diff_info_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe "diffable" do
       expect(output["examples"].first["details"]["diffable"]).to eq(true)
     end
 
+    it "captures the unescaped string string actual output" do
+      test_content = <<~RUBY
+        RSpec.describe "String diff" do
+          it "compares strings" do
+            expect('"Hello, ---world"').to match("Hello, world")  
+          end
+        end
+      RUBY
+
+      output = run_formatter_with_content(test_content)
+      # p output
+      details = output["examples"].first["details"]
+      expect(details["expected"]).to eq("Hello, world")
+      expect(details["actual"]).to eq("Hello, ---world")
+    end
+
     it "marks array comparisons as diffable" do
       test_content = <<~RUBY
         RSpec.describe "Array diff" do


### PR DESCRIPTION
Resolves #4 

### Problem

I think the issue is that the `"actual"` value in the JSON result sometimes has an escaped quoted String that we want to unescape.

### Solution

I've updated the formatter to conditionally unescape a actual String value when it is wrapped in escaped double quotes.

---

I added a test case and updated the demo
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modify `serialize_value` to unescape strings wrapped in escaped double quotes and add corresponding test case.
> 
>   - **Behavior**:
>     - Modify `serialize_value` in `expectation_helper_wrapper.rb` to unescape strings wrapped in escaped double quotes.
>     - Add test case in `diff_info_spec.rb` to verify unescaping of actual string output.
>   - **Demo**:
>     - Update `demo.rb` to include a test for unescaping quotes in actual string values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Frspec-enriched_json&utm_source=github&utm_medium=referral)<sup> for 7e55047080d05fd62fcc86cf63cd7078b8302d12. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->