### PR TITLE
Preserve symbols instead of converting to strings

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -52,6 +52,10 @@ test_content = <<~'RUBY'
       }
       expect(actual).to eq(expected)
     end
+
+    it "eq with symbols" do
+      expect(:abc).to eq(:def)
+    end
     
     # Identity Matchers
     it "be (object identity)" do
@@ -377,7 +381,7 @@ Tempfile.create(["demo_test", ".rb"]) do |test_file|
 
     # Group examples by category for better organization
     categories = {
-      "Basic Equality Matchers" => ["eq with strings", "eq with numbers", "eq with arrays", "eq with hashes", "eq with nested structures"],
+      "Basic Equality Matchers" => ["eq with strings", "eq with numbers", "eq with arrays", "eq with hashes", "eq with nested structures", "eq with symbols"],
       "Identity Matchers" => ["be (object identity)", "equal (alias for be)"],
       "Comparison Matchers" => ["be >", "be <", "be >=", "be <=", "be_between", "be_within"],
       "Type Matchers" => ["be_a / be_kind_of", "be_an_instance_of"],

--- a/lib/rspec/enriched_json/expectation_helper_wrapper.rb
+++ b/lib/rspec/enriched_json/expectation_helper_wrapper.rb
@@ -36,7 +36,7 @@ module RSpec
               truncate_string(value)
             )
           when Symbol
-            value.to_s
+            value.inspect
           when Array
             return "[Large array: #{value.size} items]" if value.size > MAX_ARRAY_SIZE
             value.map { |v| serialize_value(v, depth + 1) }

--- a/spec/diff_info_spec.rb
+++ b/spec/diff_info_spec.rb
@@ -89,6 +89,22 @@ RSpec.describe "diffable" do
       expect(output["examples"].first["details"]["diffable"]).to eq(true)
     end
 
+    it "retains symbols instead of converting to strings" do
+      test_content = <<~RUBY
+        RSpec.describe "Symbol diff" do
+          it "compares symbols" do
+            expect(:foo).to eq(:bar)
+          end
+        end
+      RUBY
+
+      output = run_formatter_with_content(test_content)
+      details = output["examples"].first["details"]
+
+      expect(details["expected"]).to eq(":bar")
+      expect(details["actual"]).to eq(":foo")
+    end
+
     it "marks different type comparisons as diffable when matcher says so" do
       test_content = <<~RUBY
         RSpec.describe "Type mismatch" do


### PR DESCRIPTION
Resolves #1 

The `.to_s` call was converting the symbols to strings. Using `.inspect` retains them as symbols. I discovered this a bit by accident during some experimentation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Preserve symbols in output by using `inspect` instead of `to_s` in `serialize_value`, with tests added to verify behavior.
> 
>   - **Behavior**:
>     - Changes `serialize_value` in `expectation_helper_wrapper.rb` to use `value.inspect` for symbols instead of `value.to_s`, preserving symbols in output.
>     - Adds test in `diff_info_spec.rb` to verify symbols are retained as symbols in output.
>     - Adds example in `demo.rb` for symbol comparison under "Basic Equality Matchers".
>   - **Tests**:
>     - Adds test case "retains symbols instead of converting to strings" in `diff_info_spec.rb`.
>     - Updates `demo.rb` to include "eq with symbols" in test categories.
>   - **Misc**:
>     - Resolves issue #1.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Frspec-enriched_json&utm_source=github&utm_medium=referral)<sup> for 41e9c0e4be003003630c1b193023466e8e1a35a8. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->