### PR TITLE
Removes the diff from exception>message if expected and actual are present

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -144,6 +144,10 @@ test_content = <<~'RUBY'
     it "match (regex)" do
       expect("user@example.com").to match(/admin@/)
     end
+
+    it "match (regex) with custom message" do
+      expect("user@example.com").to match(/admin@/), "Please provide an admin email."
+    end
     
     it "contain_exactly" do
       expect([1, 2, 3]).to contain_exactly(1, 2, 4)
@@ -383,7 +387,7 @@ Tempfile.create(["demo_test", ".rb"]) do |test_file|
       "Type Matchers" => ["be_a / be_kind_of", "be_an_instance_of"],
       "Truthiness Matchers" => ["be_truthy", "be_falsey / be_falsy", "be_nil"],
       "Predicate Matchers" => ["be_empty", "have_key"],
-      "Collection Matchers" => ["include", "include with multiple items", "include with hash", "start_with", "end_with", "match (regex)", "contain_exactly", "match_array", "all"],
+      "Collection Matchers" => ["include", "include with multiple items", "include with hash", "start_with", "end_with", "match (regex)", "match (regex) with custom message", "contain_exactly", "match_array", "all"],
       "String Matchers" => ["match with string", "unescaping quotes in actual"],
       "Change Matchers" => ["change", "change by", "change by_at_least", "change by_at_most"],
       "Output Matchers" => ["output to stdout", "output to stderr"],

--- a/lib/rspec/enriched_json/expectation_helper_wrapper.rb
+++ b/lib/rspec/enriched_json/expectation_helper_wrapper.rb
@@ -120,7 +120,7 @@ module RSpec
         details = {
           expected: Serializer.serialize_value(expected_raw),
           actual: Serializer.serialize_value(actual_raw),
-          original_message: original_message,  # Only populated when custom message overrides it
+          original_message: original_message, # Only populated when custom message overrides it
           matcher_name: matcher.class.name,
           diffable: values_diffable?(expected_raw, actual_raw, matcher)
         }

--- a/lib/rspec/enriched_json/formatters/enriched_json_formatter.rb
+++ b/lib/rspec/enriched_json/formatters/enriched_json_formatter.rb
@@ -31,7 +31,7 @@ module RSpec
 
                 if hash.key?(:details) && hash[:details].key?(:expected) && hash[:details].key?(:actual)
                   exception_message = hash[:exception][:message]
-                  if exception_message.include?("Diff:")
+                  if exception_message.match?(/\nDiff:/)
                     hash[:exception][:message] = exception_message.lines.first.chomp
                   end
                 end

--- a/lib/rspec/enriched_json/formatters/enriched_json_formatter.rb
+++ b/lib/rspec/enriched_json/formatters/enriched_json_formatter.rb
@@ -28,6 +28,13 @@ module RSpec
                 if e.is_a?(RSpec::EnrichedJson::EnrichedExpectationNotMetError) && e.details
                   hash[:details] = safe_structured_data(e.details)
                 end
+
+                if hash.key?(:details) && hash[:details].key?(:expected) && hash[:details].key?(:actual)
+                  exception_message = hash[:exception][:message]
+                  if exception_message.include?("Diff:")
+                    hash[:exception][:message] = exception_message.lines.first.chomp
+                  end
+                end
               end
             end
           end

--- a/lib/rspec/enriched_json/formatters/enriched_json_formatter.rb
+++ b/lib/rspec/enriched_json/formatters/enriched_json_formatter.rb
@@ -31,8 +31,8 @@ module RSpec
 
                 if hash.key?(:details) && hash[:details].key?(:expected) && hash[:details].key?(:actual)
                   exception_message = hash[:exception][:message]
-                  if exception_message.match?(/\nDiff:/)
-                    hash[:exception][:message] = exception_message.lines.first.chomp
+                  if exception_message.include?("\nDiff:")
+                    hash[:exception][:message] = exception_message.sub(/Diff:.*/m, "").strip
                   end
                 end
               end

--- a/spec/diff_info_spec.rb
+++ b/spec/diff_info_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "diffable" do
       expect(output["examples"].first["details"]["diffable"]).to eq(true)
     end
 
-    it "captures the unescaped string string actual output" do
+    it "captures the unescaped string actual output" do
       test_content = <<~RUBY
         RSpec.describe "String diff" do
           it "compares strings" do

--- a/spec/diff_info_spec.rb
+++ b/spec/diff_info_spec.rb
@@ -202,4 +202,12 @@ RSpec.describe "diffable" do
       expect(output["examples"].first["details"]["diffable"]).to eq(false)
     end
   end
+
+  it "removes diff from the message if expected and actual are present" do
+    expect("Your account balance is: -50").to match(/Your account balance is: [1-9]\d*/)
+  rescue RSpec::EnrichedJson::EnrichedExpectationNotMetError => e
+    expect(e.message).to include("expected \"Your account balance is: -50\"")
+    expect(e.message).to include("to match /Your account balance is:")
+    expect(e.message).not_to include("Diff:")
+  end
 end

--- a/spec/verify_custom_message_spec.rb
+++ b/spec/verify_custom_message_spec.rb
@@ -46,6 +46,6 @@ RSpec.describe "Custom message behavior verification" do
 
     # But we also preserve the original message that was overridden
     expect(e.details[:original_message]).to include("expected \"Your account balance is: -50\"")
-    expect(e.details[:original_message]).to include("to match /Your account balance is: [1-9]\\d*/")
+    expect(e.details[:original_message]).to include("to match /Your account balance is:")
   end
 end

--- a/spec/verify_custom_message_spec.rb
+++ b/spec/verify_custom_message_spec.rb
@@ -37,4 +37,15 @@ RSpec.describe "Custom message behavior verification" do
       expect(e.details[:original_message]).to be_nil
     end
   end
+
+  it "removes diff from the custom message if expected and actual are present" do
+    expect("Your account balance is: -50").to match(/Your account balance is: [1-9]\d*/), "Insufficient funds"
+  rescue RSpec::EnrichedJson::EnrichedExpectationNotMetError => e
+    # The exception message should be the custom message
+    expect(e.message).to eq("Insufficient funds")
+
+    # But we also preserve the original message that was overridden
+    expect(e.details[:original_message]).to include("expected \"Your account balance is: -50\"")
+    expect(e.details[:original_message]).to include("to match /Your account balance is: [1-9]\\d*/")
+  end
 end


### PR DESCRIPTION
Resolves #3 

### Problem

Certain matchers like `match` add the diff to `exception#message`. This is because the message is built with all [message lines](https://www.rubydoc.info/gems/rspec-core/RSpec/Core/Notifications/FailedExampleNotification#message_lines-instance_method).

<img width="876" alt="Screenshot 2025-07-09 at 5 23 36 PM" src="https://github.com/user-attachments/assets/a292f67e-e5b4-41ee-807f-06357bffcdb3" />

### Solution

The `exception#message` is constructed by combining all the `message_lines`. So the first part of the message always contains either the custom or original message followed by "Diff:". It is safe to sub out everything that comes after "Diff:" to remove the diff from the exception message.

### Testing

Run `ruby demo.rb` and manually verify that "Diff:" is not part of any exception message.

Or test an individual spec,

```ruby
RSpec.describe "Simple match test" do
  # works with a matcher
  it "checks account statement" do
    expect("Your account balance is: -50").to match(/Your account balance is: [1-9]\d*/), "Insufficient funds"
  end

  # works when comparing booleans with a custom message
  it "truth teller" do
    expect(true).to eq(false), "Obviously not."
  end

  # works without a custom message also
  it "string and symbol checker" do
    expect("abc").to eq(:abc)
  end
end
```

Then run it using,

```ruby
rspec test.rb --format RSpec::EnrichedJson::Formatters::EnrichedJsonFormatter -r ./lib/rspec/enriched_json --out test.json
```

View the JSON output,

```
cat test.json | jq .
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes diff from exception messages in `EnrichedJsonFormatter` when both expected and actual values are present, with tests verifying this behavior.
> 
>   - **Behavior**:
>     - Removes diff from `exception#message` in `EnrichedJsonFormatter` if both expected and actual values are present.
>     - Handles cases with and without custom messages.
>   - **Testing**:
>     - Adds test in `diff_info_spec.rb` to verify diff removal from messages.
>     - Adds test in `verify_custom_message_spec.rb` to ensure custom messages are preserved without diffs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Frspec-enriched_json&utm_source=github&utm_medium=referral)<sup> for b2528a0d0fccfd2cd2ee65771f949a773a666f54. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->