### PR TITLE
Serializes nil and symbol objects

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -52,6 +52,14 @@ test_content = <<~'RUBY'
       }
       expect(actual).to eq(expected)
     end
+
+    it "eq with array of symbols" do
+      expect([:name, :age]).to eq([:name])
+    end
+
+    it "eq with nil" do
+      expect("Alice").to eq(nil)
+    end
     
     # Identity Matchers
     it "be (object identity)" do
@@ -377,7 +385,7 @@ Tempfile.create(["demo_test", ".rb"]) do |test_file|
 
     # Group examples by category for better organization
     categories = {
-      "Basic Equality Matchers" => ["eq with strings", "eq with numbers", "eq with arrays", "eq with hashes", "eq with nested structures"],
+      "Basic Equality Matchers" => ["eq with strings", "eq with numbers", "eq with arrays", "eq with hashes", "eq with nested structures", "eq with array of symbols", "eq with nil"],
       "Identity Matchers" => ["be (object identity)", "equal (alias for be)"],
       "Comparison Matchers" => ["be >", "be <", "be >=", "be <=", "be_between", "be_within"],
       "Type Matchers" => ["be_a / be_kind_of", "be_an_instance_of"],

--- a/lib/rspec/enriched_json/expectation_helper_wrapper.rb
+++ b/lib/rspec/enriched_json/expectation_helper_wrapper.rb
@@ -29,14 +29,16 @@ module RSpec
           return "[Max depth exceeded]" if depth > MAX_SERIALIZATION_DEPTH
 
           case value
-          when nil, Numeric, TrueClass, FalseClass
+          when Numeric, TrueClass, FalseClass
             value
           when String
             unescape_string_double_quotes(
               truncate_string(value)
             )
           when Symbol
-            value.to_s
+            serialize_object(value)
+          when nil
+            serialize_object(value)
           when Array
             return "[Large array: #{value.size} items]" if value.size > MAX_ARRAY_SIZE
             value.map { |v| serialize_value(v, depth + 1) }

--- a/spec/edge_cases_spec.rb
+++ b/spec/edge_cases_spec.rb
@@ -56,4 +56,24 @@ RSpec.describe "Edge case handling" do
       expect(e.message).to eq("Cannot inspect!")
     end
   end
+
+  context "handling Ruby literals" do
+    it "serializes nil" do
+      expect("Alice").to eq(nil)
+    rescue RSpec::EnrichedJson::EnrichedExpectationNotMetError => e
+      # Should not crash on invalid encoding
+      expect(e.details[:expected][:class]).to eq("NilClass")
+      expect(e.details[:expected][:inspect]).to eq("nil")
+      expect(e.details[:expected][:to_s]).to eq("")
+    end
+
+    it "serializes symbols" do
+      expect(:name).to eq(:age)
+    rescue RSpec::EnrichedJson::EnrichedExpectationNotMetError => e
+      # Should not crash on invalid encoding
+      expect(e.details[:expected][:class]).to eq("Symbol")
+      expect(e.details[:expected][:inspect]).to eq(":age")
+      expect(e.details[:expected][:to_s]).to eq("age")
+    end
+  end
 end


### PR DESCRIPTION
Resolves #1 and #2

### Problem

There is no JSON equivalent of Ruby's Symbols and the NilClass. So when these values are present in the `expected` or `actual` key of the `details` object, they render out to their String format.

This causes the `expected` or `actual` values to look different than what's displayed in the `exception>message`.

### Solution

Serialize Symbol and NilClass objects. This provides the receiver with enough information to parse their JSON representation to Ruby.

### Sample test

```ruby
RSpec.describe "Simple match test" do
  it "compares with nil" do
    expect(nil).to eq(true)
  end

  it "compares with string nil" do
    expect("nil").to eq(true)
  end

  it "compares with symbol" do
    expect(:nil).to eq(true)
  end

  it "compares with string symbol" do
    expect(":nil").to eq(true)
  end

  it "compares array of symbols" do
    expect([:abc]).to eq([:def])
  end

  it "compares array of string symbols" do
    expect([":abc"]).to eq([":def"])
  end
end
```

Details object for the above test
```json
[
  {
    "expected": true,
    "actual": ":nil",
    "matcher_name": "RSpec::Matchers::BuiltIn::Eq",
    "diffable": true,
    "diff": "\n@@ -1 +1 @@\n-true\n+\":nil\"\n"
  },
  {
    "expected": true,
    "actual": {
      "class": "Symbol",
      "inspect": ":nil",
      "to_s": "nil"
    },
    "matcher_name": "RSpec::Matchers::BuiltIn::Eq",
    "diffable": true,
    "diff": "\n@@ -1 +1 @@\n-true\n+:nil\n"
  },
  {
    "expected": [
      {
        "class": "Symbol",
        "inspect": ":def",
        "to_s": "def"
      }
    ],
    "actual": [
      {
        "class": "Symbol",
        "inspect": ":abc",
        "to_s": "abc"
      }
    ],
    "matcher_name": "RSpec::Matchers::BuiltIn::Eq",
    "diffable": true,
    "diff": "\n@@ -1 +1 @@\n-[:def]\n+[:abc]\n"
  },
  {
    "expected": [":def"],
    "actual": [":abc"],
    "matcher_name": "RSpec::Matchers::BuiltIn::Eq",
    "diffable": true
  },
  {
    "expected": true,
    "actual": "nil",
    "matcher_name": "RSpec::Matchers::BuiltIn::Eq",
    "diffable": true,
    "diff": "\n@@ -1 +1 @@\n-true\n+\"nil\"\n"
  },
  {
    "expected": true,
    "actual": {
      "class": "NilClass",
      "inspect": "nil",
      "to_s": ""
    },
    "matcher_name": "RSpec::Matchers::BuiltIn::Eq",
    "diffable": true
  }
]
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Serialize `Symbol` and `NilClass` in JSON to maintain consistency in RSpec test outputs.
> 
>   - **Behavior**:
>     - Serialize `Symbol` and `NilClass` objects in `serialize_value()` in `expectation_helper_wrapper.rb` using `serialize_object()`.
>     - Ensures JSON representation can be parsed back to Ruby, maintaining consistency in `expected` and `actual` values.
>   - **Tests**:
>     - Add tests in `edge_cases_spec.rb` for serializing `nil` and `symbols`.
>     - Ensure graceful handling of circular references, matchers without `expected/actual`, and encoding issues.
>   - **Misc**:
>     - Add test cases in `demo.rb` for `eq` with array of symbols and `nil`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Frspec-enriched_json&utm_source=github&utm_medium=referral)<sup> for 3e2418ca1d170f30a6fa531d9b67d1fd6434ab60. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->