### PR TITLE
Fix serialization error when \n new lines are present

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -178,6 +178,11 @@ test_content = <<~'RUBY'
       expect("\"Hello, ---world\"").to match("Hello, world")
     end
 
+    it "strings with newlines" do
+      output = "\"l appears 1 times\"\n\"o appears 2 times\"\n\"o appears 2 times\"\n\"p appears 1 times\""
+      expect(output).to match("\"l appears 1 times\"\n\"o appears 2 times\"\n\"e appears 1 times\"\n\"p appears 1 times\"")
+    end
+
     # Change Matchers
     it "change" do
       x = 5
@@ -396,7 +401,7 @@ Tempfile.create(["demo_test", ".rb"]) do |test_file|
       "Truthiness Matchers" => ["be_truthy", "be_falsey / be_falsy", "be_nil"],
       "Predicate Matchers" => ["be_empty", "have_key"],
       "Collection Matchers" => ["include", "include with multiple items", "include with hash", "start_with", "end_with", "match (regex)", "match (regex) with custom message", "contain_exactly", "match_array", "all"],
-      "String Matchers" => ["match with string", "unescaping quotes in actual"],
+      "String Matchers" => ["match with string", "unescaping quotes in actual", "strings with newlines"],
       "Change Matchers" => ["change", "change by", "change by_at_least", "change by_at_most"],
       "Output Matchers" => ["output to stdout", "output to stderr"],
       "Exception Matchers" => ["raise_error", "raise_error with message", "raise_error when none raised", "unexpected exception (outside expect block)"],

--- a/lib/rspec/enriched_json/expectation_helper_wrapper.rb
+++ b/lib/rspec/enriched_json/expectation_helper_wrapper.rb
@@ -85,7 +85,15 @@ module RSpec
 
         def unescape_string_double_quotes(str)
           if str.start_with?('"') && str.end_with?('"')
-            return str.undump
+            begin
+              # Only undump if it's a valid dumped string
+              # Check if the string is properly escaped by attempting undump
+              str.undump
+            rescue RuntimeError => e
+              # If undump fails, just return the original string
+              # This handles cases where the string has quotes but isn't a valid dump format
+              str
+            end
           else
             str
           end

--- a/lib/rspec/enriched_json/version.rb
+++ b/lib/rspec/enriched_json/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module EnrichedJson
-    VERSION = "0.6.1"
+    VERSION = "0.6.2"
   end
 end


### PR DESCRIPTION
Resolves https://github.com/firstdraft/learn/issues/2073

## Problem

Using an expectation with `\n` new line characters in the `fuzzy_match` helper led to an error:

```ruby
expect(output).to fuzzy_match("\"l appears 1 times\"\n\"o appears 2 times\"\n\"o appears 2 times\"\n\"p appears 1 times\"")
```

```
{"class"=>"String", "serialization_error"=>"invalid dumped string; not wrapped with '\"' nor '\"...\".force_encoding(\"...\")' form"}
```

## Solution

From Claude:

> The undump method expects a properly escaped Ruby string literal, but the string being passed has newlines in the middle which makes it invalid for undump.
> 
>   The error occurs because:
>   1. The expected string in your test contains literal \n characters and escaped quotes
>   2. When fuzzy_match processes this, it may strip outer quotes but keep inner content
>   3. The enriched_json serializer sees a string that starts and ends with " and tries to undump it
>   4. But the string contains actual newline characters which make it invalid for undump
> 
>   This is indeed an expected error given the current implementation. The unescape_string_double_quotes method in the enriched_json gem is making an incorrect assumption that any string starting and ending with quotes is a valid
>   dumped string.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes serialization error in `unescape_string_double_quotes` for strings with newlines and updates tests.
> 
>   - **Behavior**:
>     - Fixes serialization error in `unescape_string_double_quotes` in `expectation_helper_wrapper.rb` when handling strings with newlines.
>     - Adds test in `edge_cases_spec.rb` to verify handling of strings with embedded newlines and quotes.
>   - **Misc**:
>     - Updates version in `version.rb` from `0.6.1` to `0.6.2`.
>     - Adds test case in `demo.rb` for strings with newlines.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Frspec-enriched_json&utm_source=github&utm_medium=referral)<sup> for a41d6bd8e971de99fad4d329441bb5aa957059e5. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->