### PR TITLE
Fixes serialization of procs

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -60,6 +60,11 @@ test_content = <<~'RUBY'
     it "eq with nil" do
       expect("Alice").to eq(nil)
     end
+
+    it "eq with proc" do
+      helloworld = proc { "Hello, world!" }
+      expect(helloworld).to eq("Hello!")
+    end
     
     # Identity Matchers
     it "be (object identity)" do
@@ -394,7 +399,7 @@ Tempfile.create(["demo_test", ".rb"]) do |test_file|
 
     # Group examples by category for better organization
     categories = {
-      "Basic Equality Matchers" => ["eq with strings", "eq with numbers", "eq with arrays", "eq with hashes", "eq with nested structures", "eq with array of symbols", "eq with nil"],
+      "Basic Equality Matchers" => ["eq with strings", "eq with numbers", "eq with arrays", "eq with hashes", "eq with nested structures", "eq with array of symbols", "eq with nil", "eq with proc"],
       "Identity Matchers" => ["be (object identity)", "equal (alias for be)"],
       "Comparison Matchers" => ["be >", "be <", "be >=", "be <=", "be_between", "be_within"],
       "Type Matchers" => ["be_a / be_kind_of", "be_an_instance_of"],
@@ -403,7 +408,6 @@ Tempfile.create(["demo_test", ".rb"]) do |test_file|
       "Collection Matchers" => ["include", "include with multiple items", "include with hash", "start_with", "end_with", "match (regex)", "match (regex) with custom message", "contain_exactly", "match_array", "all"],
       "String Matchers" => ["match with string", "unescaping quotes in actual", "strings with newlines"],
       "Change Matchers" => ["change", "change by", "change by_at_least", "change by_at_most"],
-      "Output Matchers" => ["output to stdout", "output to stderr"],
       "Exception Matchers" => ["raise_error", "raise_error with message", "raise_error when none raised", "unexpected exception (outside expect block)"],
       "Other Matchers" => ["throw_symbol", "exist", "cover", "cover multiple values", "respond_to", "respond_to with arguments", "have_attributes", "satisfy", "satisfy with complex block"],
       "Compound & Negated" => ["and", "or", "not_to eq", "not_to include"],

--- a/lib/rspec/enriched_json/expectation_helper_wrapper.rb
+++ b/lib/rspec/enriched_json/expectation_helper_wrapper.rb
@@ -45,6 +45,8 @@ module RSpec
         def serialize_value(value)
           if value.is_a?(Regexp)
             return Oj.dump(value.inspect, mode: :compat)
+          elsif value.is_a?(Proc)
+            return value.call
           end
 
           Oj.dump(value, OJ_OPTIONS)

--- a/lib/rspec/enriched_json/version.rb
+++ b/lib/rspec/enriched_json/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module EnrichedJson
-    VERSION = "0.8.0"
+    VERSION = "0.8.1"
   end
 end

--- a/lib/rspec/enriched_json/version.rb
+++ b/lib/rspec/enriched_json/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module EnrichedJson
-    VERSION = "0.8.1"
+    VERSION = "0.8.2"
   end
 end

--- a/spec/oj_serialization_spec.rb
+++ b/spec/oj_serialization_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe "Special serialization cases" do
     end
   end
 
+  describe "serialization of Proc objects" do
+    it "calls a simple Proc" do
+      helloworld = proc { "Hello, world!" }
+      result = serializer.serialize_value(helloworld)
+      expect(result).to eq("Hello, world!")
+    end
+  end
+
   describe "Fallback behavior for errors" do
     it "uses fallback format when Oj.dump fails" do
       # Create an object that we'll mock to fail


### PR DESCRIPTION
### Problem

Procs would be dumped to JSON (Oj) without being serialized. This would cause output issues.

<img width="1118" height="462" alt="471463682-349f5bde-a387-4ad4-a20f-b8189c38444b" src="https://github.com/user-attachments/assets/99af45fd-56c6-4650-89a2-6fb3dfd31889" />

### Solution

Simple procs are called as part of the serialization workflow.

What used to look like before,

```json
{
  "exception": {
    "class": "RSpec::EnrichedJson::EnrichedExpectationNotMetError",
    "message": "\nexpected: \"Hello!\"\n     got: #<Proc:0x000000012917a5f0 /var/folders/c5/717zkj_j50g1hdbnsb06z3rh0000gn/T/demo_test20250730-63756-o2wass.rb:44>\n\n(compared using ==)\n"
  },
  "details": {
    "expected": "\"Hello!\"",
    "actual": "{\"^o\":\"Proc\",\"^i\":1}",
    "original_message": null,
    "matcher_name": "RSpec::Matchers::BuiltIn::Eq",
    "diffable": true,
    "negated": false
  }
}
```

Now looks like this,

```json
{
  "exception": {
    "class": "RSpec::EnrichedJson::EnrichedExpectationNotMetError",
    "message": "\nexpected: \"Hello!\"\n     got: #<Proc:0x000000012514c410 /var/folders/c5/717zkj_j50g1hdbnsb06z3rh0000gn/T/demo_test20250730-66617-k5sedp.rb:44>\n\n(compared using ==)\n"
  },
  "details": {
    "expected": "\"Hello!\"",
    "actual": "Hello, world!",
    "original_message": null,
    "matcher_name": "RSpec::Matchers::BuiltIn::Eq",
    "diffable": true,
    "negated": false
  }
}
```

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `Proc` serialization by calling them during JSON serialization, adds tests, and updates version to `0.8.2`.
> 
>   - **Behavior**:
>     - `Proc` objects are now called during serialization in `serialize_value()` in `expectation_helper_wrapper.rb`.
>     - Adds test case for `Proc` serialization in `oj_serialization_spec.rb`.
>     - Adds example for `Proc` equality matcher in `demo.rb`.
>   - **Version**:
>     - Update version to `0.8.2` in `version.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Frspec-enriched_json&utm_source=github&utm_medium=referral)<sup> for a6cf1a74dad0cf3f335086e4617fedca3355a1fe. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->