### PR TITLE
Captures proc output instead of calling it

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -414,7 +414,8 @@ Tempfile.create(["demo_test", ".rb"]) do |test_file|
       "Custom Messages" => ["custom failure message", "custom message with block"],
       "Complex Objects" => ["struct comparison", "custom class object comparison", "test with metadata", "custom object with many instance variables"],
       "Fuzzy Matchers" => ["a_string_matching", "a_hash_including", "a_collection_containing_exactly", "an_instance_of", "include with hash conditions"],
-      "Yield Matchers" => ["yield_control", "yield_with_args"]
+      "Yield Matchers" => ["yield_control", "yield_with_args"],
+      "Output Matchers" => ["output to stdout", "output to stderr"]
     }
 
     categories.each do |category, descriptions|

--- a/lib/rspec/enriched_json/expectation_helper_wrapper.rb
+++ b/lib/rspec/enriched_json/expectation_helper_wrapper.rb
@@ -4,6 +4,7 @@ require "json"
 require "oj"
 require "rspec/expectations"
 require "rspec/support/differ"
+require "stringio"
 
 module RSpec
   module EnrichedJson
@@ -46,7 +47,15 @@ module RSpec
           if value.is_a?(Regexp)
             return Oj.dump(value.inspect, mode: :compat)
           elsif value.is_a?(Proc)
-            return value.call
+            original_stdout = $stdout
+            $stdout = StringIO.new
+
+            value.call
+
+            output = $stdout.string
+            $stdout = original_stdout
+
+            return output
           end
 
           Oj.dump(value, OJ_OPTIONS)

--- a/lib/rspec/enriched_json/version.rb
+++ b/lib/rspec/enriched_json/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module EnrichedJson
-    VERSION = "0.8.2"
+    VERSION = "0.8.3"
   end
 end

--- a/spec/oj_serialization_spec.rb
+++ b/spec/oj_serialization_spec.rb
@@ -42,15 +42,6 @@ RSpec.describe "Special serialization cases" do
       expect(result).to eq("/http:\\/\\/example\\.com/")
     end
   end
-
-  describe "serialization of Proc objects" do
-    it "calls a simple Proc" do
-      helloworld = proc { "Hello, world!" }
-      result = serializer.serialize_value(helloworld)
-      expect(result).to eq("Hello, world!")
-    end
-  end
-
   describe "Fallback behavior for errors" do
     it "uses fallback format when Oj.dump fails" do
       # Create an object that we'll mock to fail

--- a/spec/stdout_matcher_spec.rb
+++ b/spec/stdout_matcher_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Stdout matcher value capture" do
+  let(:formatter) { RSpec::EnrichedJson::Formatters::EnrichedJsonFormatter.new(StringIO.new) }
+
+  # Use the same Oj options for loading that we use for dumping
+  let(:oj_load_options) do
+    {
+      mode: :object,
+      symbol_keys: true,
+      auto_define: false,
+      create_additions: false
+    }
+  end
+
+  it "captures actual when spec passes" do
+    test_file = "spec/support/stdout_passing_spec.rb"
+    File.write(test_file, <<~RUBY)
+      RSpec.describe "Test" do
+        it "checks output" do
+          expect { puts "Hello" }.to output("Hello\\n").to_stdout
+        end
+      end
+    RUBY
+
+    output = run_rspec(test_file)
+    json = Oj.load(output)
+    example = json["examples"].first
+
+    expect(example["details"]["expected"]).to eq("\"Hello\\n\"")
+    expect(example["details"]["actual"]).to eq("Hello\n")
+  ensure
+    File.delete(test_file) if File.exist?(test_file)
+  end
+
+  it "captures actual when spec fails" do
+    test_file = "spec/support/stdout_passing_spec.rb"
+    File.write(test_file, <<~RUBY)
+      RSpec.describe "Test" do
+        it "checks output" do
+          expect { puts "Hello" }.to output("Bye\\n").to_stdout
+        end
+      end
+    RUBY
+
+    output = run_rspec(test_file)
+    json = Oj.load(output)
+    example = json["examples"].first
+
+    expect(example["details"]["expected"]).to eq("\"Bye\\n\"")
+    expect(example["details"]["actual"]).to eq("\"Hello\\n\"")
+  ensure
+    File.delete(test_file) if File.exist?(test_file)
+  end
+
+  private
+
+  def run_rspec(test_file)
+    output = nil
+    Dir.mktmpdir do |dir|
+      output_file = File.join(dir, "output.json")
+      cmd = "bundle exec rspec #{test_file} --format RSpec::EnrichedJson::Formatters::EnrichedJsonFormatter --out #{output_file} 2>&1"
+      system(cmd, out: File::NULL)
+      output = File.read(output_file)
+    end
+    output
+  end
+end


### PR DESCRIPTION
A specific bug occurs with TodoList specs where the proc that is captured by the exception refers to a portion of the code which returns an array but outputs a string.

<img width="642" height="100" alt="Screenshot 2025-08-05 at 11 17 29 PM" src="https://github.com/user-attachments/assets/cabf7f82-6497-4508-86ab-558382dbc684" />

This array causes issues when showing the HTML diff:

<img width="1261" height="705" alt="Screenshot 2025-08-05 at 10 45 55 PM" src="https://github.com/user-attachments/assets/11142b4a-2ce2-4291-a31e-f8b13dc588c9" />

To solve this, I capture the output of the proc instead of calling it.

## Testing

Test this using the following script (add it to the root of this repository):

```ruby
# bundle exec rspec stdout_demo.rb --format RSpec::EnrichedJson::Formatters::EnrichedJsonFormatter -r ./lib/rspec/enriched_json

RSpec.describe "stdout" do
  it "captures actual when spec fails" do
    expect { puts "Hello" }.to output("Bye\n").to_stdout
  end

  it "captures actual when spec passes" do
    expect { puts "Hello" }.to output("Hello\n").to_stdout
  end
end
```

Both cases should return an actual that is a string — not an array.

## Learn Output

The specs on Learn now look like this:

When the spec fails:
<img width="1136" height="400" alt="Screenshot 2025-08-05 at 11 30 51 PM" src="https://github.com/user-attachments/assets/a34d62d3-901b-4559-824e-183a989b90eb" />

When the spec passes:
<img width="1133" height="278" alt="Screenshot 2025-08-05 at 11 31 27 PM" src="https://github.com/user-attachments/assets/426a8356-5bec-4222-929d-e4bc0f18f9d3" /> 

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Capture `Proc` output to `stdout` in `serialize_value` and add tests for output matchers.
> 
>   - **Behavior**:
>     - Modify `serialize_value` in `ExpectationHelperWrapper` to capture `Proc` output to `stdout` instead of calling it directly.
>     - Add "Output Matchers" category in `demo.rb`.
>   - **Tests**:
>     - Remove `Proc` serialization test in `oj_serialization_spec.rb`.
>     - Add `stdout_matcher_spec.rb` to test capturing of `stdout` output for passing and failing cases.
>   - **Version**:
>     - Increment version to `0.8.3` in `version.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Frspec-enriched_json&utm_source=github&utm_medium=referral)<sup> for 28c7483808f2601a737286954b414d464b4eb988. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->